### PR TITLE
feat: add suggestion to switch import aliases to ESM import

### DIFF
--- a/docs/rules/import-aliases.md
+++ b/docs/rules/import-aliases.md
@@ -4,6 +4,14 @@
 
 Enforces that code doesn't use TypeScript's `import ... =`s:
 
+## Invalid Code
+
 ```ts
 import values = require("values");
+```
+
+## Valid Code
+
+```ts
+import values from "values";
 ```

--- a/src/rules/import-aliases.test.ts
+++ b/src/rules/import-aliases.test.ts
@@ -12,6 +12,12 @@ ruleTester.run("import-aliases", rule, {
 					endLine: 1,
 					line: 1,
 					messageId: "importAlias",
+					suggestions: [
+						{
+							messageId: "importAliasFix",
+							output: `import values from "values";`,
+						},
+					],
 				},
 			],
 		},

--- a/src/rules/import-aliases.ts
+++ b/src/rules/import-aliases.ts
@@ -9,9 +9,24 @@ export const rule = createRule({
 				if (
 					node.moduleReference.type === AST_NODE_TYPES.TSExternalModuleReference
 				) {
+					const importName = node.id.name;
+					const importModule = node.moduleReference.expression.value;
+
 					context.report({
 						messageId: "importAlias",
 						node,
+						suggest: [
+							{
+								data: { module: importModule, name: importName },
+								fix(fixer) {
+									return fixer.replaceText(
+										node,
+										`import ${importName} from "${importModule}";`,
+									);
+								},
+								messageId: "importAliasFix",
+							},
+						],
 					});
 				}
 			},
@@ -22,9 +37,12 @@ export const rule = createRule({
 		docs: {
 			description: "Avoid using TypeScript's import aliases.",
 		},
+		fixable: "code",
+		hasSuggestions: true,
 		messages: {
 			importAlias:
 				"This import alias will not be allowed under TypeScript's --erasableSyntaxOnly.",
+			importAliasFix: "Use `import {{name}} from '{{module}}'` instead.",
 		},
 		schema: [],
 		type: "problem",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-erasable-syntax-only! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #009
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

- Add suggestion to switch import aliases to an ESM import
- Update docs

💖