### PR TITLE
chore: finish setting up ESLint plugin and all-contributors tooling

### DIFF
--- a/.eslint-doc-generatorrc.cjs
+++ b/.eslint-doc-generatorrc.cjs
@@ -1,5 +1,12 @@
+const prettier = require("prettier");
+
 /** @type {import('eslint-doc-generator').GenerateOptions} */
 const config = {
+	postprocess: async (content, path) =>
+		prettier.format(content, {
+			...(await prettier.resolveConfig(path)),
+			parser: "markdown",
+		}),
 	ruleDocTitleFormat: "prefix-name",
 };
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+.all-contributorsrc
 /.husky
 /coverage
 /lib

--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ These are all set to `"error"` in the recommended config:
 
 <!-- begin auto-generated rules list -->
 
-| Name                                                       | Description                                          |
-| :--------------------------------------------------------- | :--------------------------------------------------- |
-| [enums](docs/rules/enums.md)                               | Avoid using TypeScript's enums.                      |
-| [import-aliases](docs/rules/import-aliases.md)             | Avoid using TypeScript's import aliases.             |
-| [namespaces](docs/rules/namespaces.md)                     | Avoid using TypeScript's namespaces.                 |
-| [parameter-properties](docs/rules/parameter-properties.md) | Avoid using TypeScript's class parameter properties. |
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
+| Name                                                       | Description                                          | 💡  |
+| :--------------------------------------------------------- | :--------------------------------------------------- | :-- |
+| [enums](docs/rules/enums.md)                               | Avoid using TypeScript's enums.                      |     |
+| [import-aliases](docs/rules/import-aliases.md)             | Avoid using TypeScript's import aliases.             | 💡  |
+| [namespaces](docs/rules/namespaces.md)                     | Avoid using TypeScript's namespaces.                 |     |
+| [parameter-properties](docs/rules/parameter-properties.md) | Avoid using TypeScript's class parameter properties. |     |
 
 <!-- end auto-generated rules list -->
 
@@ -113,5 +115,26 @@ export default tseslint.config(
 
 See [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md), then [`.github/DEVELOPMENT.md`](./.github/DEVELOPMENT.md).
 Thanks! 💖
+
+## Contributors
+
+<!-- spellchecker: disable -->
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/AlexMunoz"><img src="https://avatars.githubusercontent.com/u/3093946?v=4?s=100" width="100px;" alt="Alex Muñoz"/><br /><sub><b>Alex Muñoz</b></sub></a><br /><a href="https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/commits?author=alexmunoz" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://www.joshuakgoldberg.com/"><img src="https://avatars.githubusercontent.com/u/3335181?v=4?s=100" width="100px;" alt="Josh Goldberg ✨"/><br /><sub><b>Josh Goldberg ✨</b></sub></a><br /><a href="https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/commits?author=JoshuaKGoldberg" title="Code">💻</a> <a href="#content-JoshuaKGoldberg" title="Content">🖋</a> <a href="https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/commits?author=JoshuaKGoldberg" title="Documentation">📖</a> <a href="#ideas-JoshuaKGoldberg" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-JoshuaKGoldberg" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#maintenance-JoshuaKGoldberg" title="Maintenance">🚧</a> <a href="#projectManagement-JoshuaKGoldberg" title="Project Management">📆</a> <a href="#tool-JoshuaKGoldberg" title="Tools">🔧</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+<!-- spellchecker: enable -->
 
 > 💝 This package was templated with [`create-typescript-app`](https://github.com/JoshuaKGoldberg/create-typescript-app) using the [Bingo engine](https://create.bingo).

--- a/docs/rules/import-aliases.md
+++ b/docs/rules/import-aliases.md
@@ -1,5 +1,7 @@
 # erasable-syntax-only/import-aliases
 
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
 <!-- end auto-generated rule header -->
 
 Enforces that code doesn't use TypeScript's `import ... =`s:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import comments from "@eslint-community/eslint-plugin-eslint-comments/configs";
 import eslint from "@eslint/js";
 import vitest from "@vitest/eslint-plugin";
+import eslintPlugin from "eslint-plugin-eslint-plugin";
 import jsdoc from "eslint-plugin-jsdoc";
 import jsonc from "eslint-plugin-jsonc";
 import markdown from "eslint-plugin-markdown";
@@ -25,6 +26,7 @@ export default tseslint.config(
 	},
 	{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 	eslint.configs.recommended,
+	eslintPlugin.configs["flat/recommended"],
 	comments.recommended,
 	jsdoc.configs["flat/contents-typescript-error"],
 	jsdoc.configs["flat/logical-typescript-error"],

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"cspell": "8.17.3",
 		"eslint": "9.20.1",
 		"eslint-doc-generator": "2.0.2",
+		"eslint-plugin-eslint-plugin": "^6.4.0",
 		"eslint-plugin-jsdoc": "50.6.3",
 		"eslint-plugin-jsonc": "2.19.1",
 		"eslint-plugin-markdown": "5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       eslint-doc-generator:
         specifier: 2.0.2
         version: 2.0.2(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
+      eslint-plugin-eslint-plugin:
+        specifier: ^6.4.0
+        version: 6.4.0(eslint@9.20.1(jiti@2.4.2))
       eslint-plugin-jsdoc:
         specifier: 50.6.3
         version: 50.6.3(eslint@9.20.1(jiti@2.4.2))
@@ -1752,6 +1755,12 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8'
+
+  eslint-plugin-eslint-plugin@6.4.0:
+    resolution: {integrity: sha512-X94/hr7DnckX68wE6Qqeo3DsZndZSclfoewjwD249yG5z2EAOl3UGUohLIgOpmbUjcFv6AlfW3wxBnOiWkS1Iw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.23.0'
 
   eslint-plugin-jsdoc@50.6.3:
     resolution: {integrity: sha512-NxbJyt1M5zffPcYZ8Nb53/8nnbIScmiLAMdoe0/FAszwb7lcSiX3iYBTsuF7RV84dZZJC8r3NghomrUXsmWvxQ==}
@@ -5198,6 +5207,12 @@ snapshots:
       '@eslint-community/regexpp': 4.12.1
       eslint: 9.20.1(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.20.1(jiti@2.4.2))
+
+  eslint-plugin-eslint-plugin@6.4.0(eslint@9.20.1(jiti@2.4.2)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@2.4.2))
+      eslint: 9.20.1(jiti@2.4.2)
+      estraverse: 5.3.0
 
   eslint-plugin-jsdoc@50.6.3(eslint@9.20.1(jiti@2.4.2)):
     dependencies:

--- a/src/rules/import-aliases.ts
+++ b/src/rules/import-aliases.ts
@@ -37,7 +37,6 @@ export const rule = createRule({
 		docs: {
 			description: "Avoid using TypeScript's import aliases.",
 		},
-		fixable: "code",
 		hasSuggestions: true,
 		messages: {
 			importAlias:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue:
  * fixes #15
  * fixes #16
  * fixes #17
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes a bunch of tooling issues all at once. Normally I would split these up, but they're in similar areas and the package is just a day or two old. 🙂 

* Sets eslint-doc-generator to format with Prettier
* Ignores `.all-contributorsrc` for Prettier, since the auto-generated file isn't formatted correctly _(again, sigh)_
* Refreshes the README.md table of rules by re-running `pnpm build:docs` after `pnpm build`
* Adds `eslint-plugin-eslint-plugin`'s recommended config
* Removes `fixable: "code"` from the `import-aliases` rule

💖 