### PR TITLE
fix(namespaces): only report when there is value emit

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
 		"automerge",
 		"joshuakgoldberg",
 		"markdownlintignore",
-		"tseslint"
+		"tseslint",
+		"TSESTree"
 	]
 }

--- a/docs/rules/namespaces.md
+++ b/docs/rules/namespaces.md
@@ -4,6 +4,8 @@
 
 Enforces that code doesn't use TypeScript's `namespaces` with values:
 
+## Invalid Code
+
 ```ts
 module Values {
 	export const value = "a";
@@ -11,5 +13,17 @@ module Values {
 
 namespace Values {
 	export const value = "a";
+}
+```
+
+## Valid Code
+
+```ts
+module Values {
+	export type Value = "a";
+}
+
+namespace Values {
+	export type Value = "a";
 }
 ```

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
-		"@typescript-eslint/utils": "^8.24.0"
+		"@typescript-eslint/utils": "^8.24.0",
+		"cached-factory": "^0.1.0"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@typescript-eslint/utils':
         specifier: ^8.24.0
         version: 8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
+      cached-factory:
+        specifier: ^0.1.0
+        version: 0.1.0
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.4.1
@@ -1276,6 +1279,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cached-factory@0.1.0:
+    resolution: {integrity: sha512-IGOSWu+NuED5UzCRmBeqQPZ8z7SkgrD/nN67W2iY1Qv83CVhevyMexkGclJ86saXisIqxoOnbeiTWvsCHRqJBw==}
+    engines: {node: '>=18'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -4692,6 +4699,8 @@ snapshots:
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
+
+  cached-factory@0.1.0: {}
 
   callsites@3.1.0: {}
 

--- a/src/rules/namespaces.test.ts
+++ b/src/rules/namespaces.test.ts
@@ -4,49 +4,260 @@ import { ruleTester } from "./ruleTester.js";
 ruleTester.run("namespaces", rule, {
 	invalid: [
 		{
-			code: `module Values {}`,
+			code: `
+				module Values {
+					export const value = 'a';
+				}
+			`,
 			errors: [
 				{
-					column: 1,
-					endColumn: 17,
-					endLine: 1,
-					line: 1,
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
 					messageId: "namespace",
 				},
 			],
 		},
 		{
-			code: `module Values.Inner {}`,
+			code: `
+				namespace Values {
+					export const value = 'a';
+				}
+			`,
 			errors: [
 				{
-					column: 1,
-					endColumn: 23,
-					endLine: 1,
-					line: 1,
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
 					messageId: "namespace",
 				},
 			],
 		},
 		{
-			code: `namespace Values {}`,
+			code: `
+				namespace Values {
+					export namespace Inner {
+						export const value = 'a';
+					}
+				}
+			`,
 			errors: [
 				{
-					column: 1,
-					endColumn: 20,
-					endLine: 1,
-					line: 1,
+					column: 5,
+					endColumn: 6,
+					endLine: 6,
+					line: 2,
 					messageId: "namespace",
 				},
 			],
 		},
 		{
-			code: `namespace Values.Inner {}`,
+			code: `
+				namespace Value {
+					export class A { }
+				}
+			`,
 			errors: [
 				{
-					column: 1,
-					endColumn: 26,
-					endLine: 1,
-					line: 1,
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				module Values.Inner {
+					export const value = 'a';
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				export module Values.Inner {
+					export const value = 'a';
+				}
+			`,
+			errors: [
+				{
+					column: 12,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values.Inner {
+					export const value = 'a';
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				export namespace Values.Inner {
+					export const value = 'a';
+				}
+			`,
+			errors: [
+				{
+					column: 12,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				namespace Value {
+					export function a(): void;
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				namespace Declared {
+					export declare class A { }
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				namespace Value {
+					export enum A { }
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				namespace Declared {
+					export declare function a(): void;
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				namespace Declared {
+					export declare enum A { }
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				namespace Declared {
+					export declare const a: 'a';
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				namespace Invalid {
+					export {};
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				const a = 'a';
+				namespace Invalid {
+					export { a };
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 5,
+					line: 3,
 					messageId: "namespace",
 				},
 			],
@@ -55,7 +266,92 @@ ruleTester.run("namespaces", rule, {
 	valid: [
 		`const Values = {};`,
 		`module 'values' {}`,
-		"declare module Values {}",
-		"declare namespace Values {}",
+		`module Empty {}`,
+		`namespace Empty {}`,
+		`export namespace Empty {}`,
+		`
+			namespace Empty {}
+			export {};
+		`,
+		`
+			namespace Types {
+				interface A {}
+			}
+		`,
+		`
+			namespace Types {
+				declare interface A {}
+			}
+		`,
+		`
+			namespace Types {
+				export interface A {}
+			}
+		`,
+		`
+			namespace Types {
+				export declare interface A {}
+			}
+		`,
+		`
+			namespace Types {
+				type A = 'a';
+			}
+		`,
+		`
+			namespace Types {
+				declare type A = 'a';
+			}
+		`,
+		`
+			namespace Types {
+				export type A = 'a';
+			}
+		`,
+		`
+			namespace Types {
+				export declare type A = 'a';
+			}
+		`,
+		`declare module Empty {}`,
+		`declare namespace Empty {}`,
+		`
+			namespace NotInstantiated {
+				export interface JustAType { }
+				export type ATypeInANamespace = {};
+				namespace Nested {
+					export type ATypeInANamespace = {};
+				}
+			}
+		`,
+		`
+			declare namespace AmbientIsNotInstantiated {
+				export const stillOk = 12;
+			}
+		`,
+		`
+			declare namespace AmbientStuff {
+				namespace Nested {
+					export const stillOk = 12;
+				}
+				enum EnumInAmbientContext {
+					B = 1
+				}
+			
+				import FineAlias = EnumInAmbientContext.B;
+			}
+		`,
+		`
+			declare namespace AmbientStuff {
+				export namespace Nested {
+					export const stillOk = 12;
+				}
+				enum EnumInAmbientContext {
+					B = 1
+				}
+			
+				import FineAlias = EnumInAmbientContext.B;
+			}
+		`,
 	],
 });

--- a/src/rules/namespaces.ts
+++ b/src/rules/namespaces.ts
@@ -1,19 +1,61 @@
-import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { CachedFactory } from "cached-factory";
 
 import { createRule } from "../utils.js";
 
+function skipExportParent(node: TSESTree.Node & { parent: object }) {
+	return node.parent.type == AST_NODE_TYPES.ExportNamedDeclaration
+		? node.parent
+		: node;
+}
+
+function skipModuleParent(node: TSESTree.Node & { parent: object }) {
+	return node.parent.type === AST_NODE_TYPES.TSModuleDeclaration
+		? node.parent
+		: node;
+}
+
 export const rule = createRule({
 	create(context) {
+		const hasValueStatementCache = new CachedFactory(
+			(node: TSESTree.TSModuleDeclaration) =>
+				!node.declare &&
+				node.id.type !== AST_NODE_TYPES.Literal &&
+				// https://github.com/typescript-eslint/typescript-eslint/issues/10486
+				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+				node.body.body.some?.(isValueStatement),
+		);
+
+		function isValueStatement(
+			node: TSESTree.NamedExportDeclarations | TSESTree.ProgramStatement,
+		): boolean {
+			switch (node.type) {
+				case AST_NODE_TYPES.ExportNamedDeclaration:
+					// "Export declarations are not permitted in a namespace.":
+					// node.declaration is only null for disallowed `export { ... }`s.
+					return !node.declaration || isValueStatement(node.declaration);
+
+				case AST_NODE_TYPES.TSInterfaceDeclaration:
+				case AST_NODE_TYPES.TSTypeAliasDeclaration:
+					return false;
+
+				case AST_NODE_TYPES.TSModuleDeclaration:
+					return hasValueStatementCache.get(node);
+
+				default:
+					return true;
+			}
+		}
+
 		return {
 			TSModuleDeclaration(node) {
 				if (
-					!node.declare &&
-					node.id.type !== AST_NODE_TYPES.Literal &&
-					node.parent.type !== AST_NODE_TYPES.TSModuleDeclaration
+					hasValueStatementCache.get(node) &&
+					skipExportParent(node).parent.type !== AST_NODE_TYPES.TSModuleBlock
 				) {
 					context.report({
 						messageId: "namespace",
-						node,
+						node: skipModuleParent(node),
 					});
 				}
 			},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #22
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes the rule to not report when no value emit child is found in a namespace.

Adds [`cached-factory`](https://www.npmjs.com/package/cached-factory) as a dependency to cache checks on individual namespace nodes. Parent namespaces need to check their child namespaces.

💖 