### PR TITLE
docs(readme): use gfm alert for tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ export default tseslint.config(
 );
 ```
 
-> 💡 Tip: Put a _TODO_ comment linking to a tracking issue/ticket on any temporary disables of rules.
+> [!TIP]
+> Put a _TODO_ comment linking to a tracking issue/ticket on any temporary disables of rules.
 > It will help keep track of pending work and indicate when rule disables aren't meant to stay long-term.
 
 ### See Also


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-erasable-syntax-only! ❎
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #238 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Replaces tip block quote syntax with gfm alert syntax.

💡