### PR TITLE
feat: [namespaces] add suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ These are all set to `"error"` in the recommended config:
 | :--------------------------------------------------------- | :--------------------------------------------------- | :-- |
 | [enums](docs/rules/enums.md)                               | Avoid using TypeScript's enums.                      | 💡  |
 | [import-aliases](docs/rules/import-aliases.md)             | Avoid using TypeScript's import aliases.             | 💡  |
-| [namespaces](docs/rules/namespaces.md)                     | Avoid using TypeScript's namespaces.                 |     |
+| [namespaces](docs/rules/namespaces.md)                     | Avoid using TypeScript's namespaces.                 | 💡  |
 | [parameter-properties](docs/rules/parameter-properties.md) | Avoid using TypeScript's class parameter properties. |     |
 
 <!-- end auto-generated rules list -->

--- a/docs/rules/namespaces.md
+++ b/docs/rules/namespaces.md
@@ -2,6 +2,8 @@
 
 📝 Avoid using TypeScript's namespaces.
 
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
 <!-- end auto-generated rule header -->
 
 Enforces that code doesn't use TypeScript's `namespaces` with values:
@@ -28,4 +30,10 @@ module Values {
 namespace Values {
 	export type Value = "a";
 }
+```
+
+```ts
+const Values = {
+	value: "a",
+};
 ```

--- a/src/rules/namespaces.test.ts
+++ b/src/rules/namespaces.test.ts
@@ -16,6 +16,24 @@ ruleTester.run("namespaces", rule, {
 					endLine: 4,
 					line: 2,
 					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				
+					const value = 'a';
+				
+			`,
+						},
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const Values = {
+					value: 'a',
+				};
+			`,
+						},
+					],
 				},
 			],
 		},
@@ -30,6 +48,201 @@ ruleTester.run("namespaces", rule, {
 					column: 5,
 					endColumn: 6,
 					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				
+					const value = 'a';
+				
+			`,
+						},
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const Values = {
+					value: 'a',
+				};
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				export namespace Values {
+					export const value = 'a';
+				}
+			`,
+			errors: [
+				{
+					column: 12,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				
+					export const value = 'a';
+				
+			`,
+						},
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				export const Values = {
+					value: 'a',
+				};
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					export const value: string = 'a';
+					export let other = 'b', third = 'c';
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 5,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				
+					const value: string = 'a';
+					let other = 'b', third = 'c';
+				
+			`,
+						},
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const Values = {
+					value: 'a',
+					other: 'b', third: 'c',
+				};
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					export function value() {}
+					export async function asynchronous() {}
+					export function* generator() {}
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 6,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				
+					function value() {}
+					async function asynchronous() {}
+					function* generator() {}
+				
+			`,
+						},
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const Values = {
+					value() {},
+					async asynchronous() {},
+					* generator() {},
+				};
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					export const value = 'a';
+					export function getValue() {
+						return value;
+					}
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 7,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				
+					const value = 'a';
+					function getValue() {
+						return value;
+					}
+				
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					export const a = 'a';
+					export const b = Values.a;
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 5,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					const hidden = 'a';
+					export const value = 'b';
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 5,
 					line: 2,
 					messageId: "namespace",
 				},

--- a/src/rules/namespaces.ts
+++ b/src/rules/namespaces.ts
@@ -1,7 +1,40 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
 import { CachedFactory } from "cached-factory";
 
 import { createRule } from "../utils.js";
+
+interface ConvertibleDeclarator {
+	init: TSESTree.Expression;
+	nameEnd: number;
+	nameStart: number;
+}
+
+interface ConvertibleFunction extends ConvertibleStatementBase {
+	functionRange: TSESTree.Range;
+	type: "function";
+}
+
+interface ConvertibleNamespace {
+	body: TSESTree.TSModuleBlock;
+	id: TSESTree.Identifier;
+	statements: ConvertibleStatement[];
+}
+
+type ConvertibleStatement = ConvertibleFunction | ConvertibleVariable;
+
+interface ConvertibleStatementBase {
+	declarationRange: TSESTree.Range;
+	isReferenced: boolean;
+	lastToken: TSESTree.Token;
+	statement: TSESTree.ExportNamedDeclaration;
+}
+
+interface ConvertibleVariable extends ConvertibleStatementBase {
+	declarators: ConvertibleDeclarator[];
+	type: "variable";
+}
+
+type MessageId = "namespace" | "namespaceObjectFix" | "namespaceRemoveFix";
 
 function skipExportParent(node: TSESTree.Node & { parent: object }) {
 	return node.parent.type == AST_NODE_TYPES.ExportNamedDeclaration
@@ -47,15 +80,234 @@ export const rule = createRule({
 			}
 		}
 
+		function getConvertibleNamespace(
+			node: TSESTree.TSModuleDeclaration,
+		): ConvertibleNamespace | undefined {
+			const { body, id } = node;
+
+			if (
+				body?.type !== AST_NODE_TYPES.TSModuleBlock ||
+				id.type !== AST_NODE_TYPES.Identifier ||
+				isSelfReferential(node, body)
+			) {
+				return undefined;
+			}
+
+			const statements: ConvertibleStatement[] = [];
+
+			for (const statement of body.body) {
+				const converted = getConvertibleStatement(statement);
+				if (!converted) {
+					return undefined;
+				}
+
+				statements.push(converted);
+			}
+
+			return { body, id, statements };
+		}
+
+		function getConvertibleStatement(
+			statement: TSESTree.ProgramStatement,
+		): ConvertibleStatement | undefined {
+			if (
+				statement.type !== AST_NODE_TYPES.ExportNamedDeclaration ||
+				!statement.declaration
+			) {
+				return undefined;
+			}
+
+			const { declaration } = statement;
+			const lastToken = context.sourceCode.getLastToken(statement);
+
+			if (!lastToken) {
+				return undefined;
+			}
+
+			const isReferenced = context.sourceCode
+				.getDeclaredVariables(declaration)
+				.some((variable) =>
+					variable.references.some((reference) => !reference.init),
+				);
+
+			switch (declaration.type) {
+				case AST_NODE_TYPES.FunctionDeclaration: {
+					const functionRange = getFunctionKeywordRange(declaration);
+
+					return functionRange
+						? {
+								declarationRange: declaration.range,
+								functionRange,
+								isReferenced,
+								lastToken,
+								statement,
+								type: "function",
+							}
+						: undefined;
+				}
+
+				case AST_NODE_TYPES.VariableDeclaration: {
+					const declarators: ConvertibleDeclarator[] = [];
+
+					for (const { id, init } of declaration.declarations) {
+						if (id.type !== AST_NODE_TYPES.Identifier || !init) {
+							return undefined;
+						}
+
+						declarators.push({
+							init,
+							// Identifier ranges include any type annotation, which an
+							// object property can't have.
+							nameEnd: id.typeAnnotation?.range[0] ?? id.range[1],
+							nameStart: id.range[0],
+						});
+					}
+
+					return {
+						declarationRange: declaration.range,
+						declarators,
+						isReferenced,
+						lastToken,
+						statement,
+						type: "variable",
+					};
+				}
+
+				default:
+					return undefined;
+			}
+		}
+
+		function getFunctionKeywordRange(
+			declaration: TSESTree.FunctionDeclaration,
+		): TSESTree.Range | undefined {
+			const functionToken = context.sourceCode.getFirstToken(
+				declaration,
+				(token) => token.value === "function",
+			);
+			const tokenAfter =
+				functionToken && context.sourceCode.getTokenAfter(functionToken);
+
+			return functionToken && tokenAfter
+				? [functionToken.range[0], tokenAfter.range[0]]
+				: undefined;
+		}
+
+		function isSelfReferential(
+			node: TSESTree.TSModuleDeclaration,
+			body: TSESTree.TSModuleBlock,
+		) {
+			return context.sourceCode
+				.getDeclaredVariables(node)
+				.some(
+					(variable) =>
+						variable.defs.length > 1 ||
+						variable.references.some(
+							(reference) =>
+								reference.identifier.range[0] >= body.range[0] &&
+								reference.identifier.range[1] <= body.range[1],
+						),
+				);
+		}
+
+		function createSuggestions(
+			node: TSESTree.TSModuleDeclaration,
+		): TSESLint.SuggestionReportDescriptor<MessageId>[] | undefined {
+			const convertible = getConvertibleNamespace(node);
+
+			if (!convertible) {
+				return undefined;
+			}
+
+			const { body, id, statements } = convertible;
+
+			const suggestions: TSESLint.SuggestionReportDescriptor<MessageId>[] = [
+				{
+					*fix(fixer) {
+						const target = skipExportParent(node);
+
+						yield fixer.removeRange([target.range[0], body.range[0] + 1]);
+						yield fixer.removeRange([body.range[1] - 1, body.range[1]]);
+
+						if (target === node) {
+							for (const { declarationRange, statement } of statements) {
+								yield fixer.removeRange([
+									statement.range[0],
+									declarationRange[0],
+								]);
+							}
+						}
+					},
+					messageId: "namespaceRemoveFix",
+				},
+			];
+
+			// Members referenced by other members would no longer be in scope as
+			// properties of an object, so only namespaces without them can convert.
+			if (!statements.some((statement) => statement.isReferenced)) {
+				suggestions.push({
+					*fix(fixer) {
+						yield fixer.replaceTextRange(
+							[node.range[0], body.range[0] + 1],
+							`const ${id.name} = {`,
+						);
+
+						for (const converted of statements) {
+							yield* createPropertyFixes(fixer, converted);
+						}
+
+						yield fixer.replaceTextRange(
+							[body.range[1] - 1, body.range[1]],
+							"};",
+						);
+					},
+					messageId: "namespaceObjectFix",
+				});
+			}
+
+			return suggestions;
+		}
+
+		function* createPropertyFixes(
+			fixer: TSESLint.RuleFixer,
+			converted: ConvertibleStatement,
+		) {
+			const { lastToken, statement } = converted;
+
+			if (converted.type === "variable") {
+				yield fixer.removeRange([
+					statement.range[0],
+					converted.declarators[0].nameStart,
+				]);
+
+				for (const { init, nameEnd } of converted.declarators) {
+					yield fixer.replaceTextRange([nameEnd, init.range[0]], ": ");
+				}
+			} else {
+				yield fixer.removeRange([
+					statement.range[0],
+					converted.declarationRange[0],
+				]);
+				yield fixer.removeRange(converted.functionRange);
+			}
+
+			yield lastToken.value === ";"
+				? fixer.replaceText(lastToken, ",")
+				: fixer.insertTextAfter(statement, ",");
+		}
+
 		return {
 			TSModuleDeclaration(node) {
 				if (
 					hasValueStatementCache.get(node) &&
 					skipExportParent(node).parent.type !== AST_NODE_TYPES.TSModuleBlock
 				) {
+					const reported = skipModuleParent(node);
+
 					context.report({
 						messageId: "namespace",
-						node: skipModuleParent(node),
+						node: reported,
+						suggest: reported === node ? createSuggestions(node) : undefined,
 					});
 				}
 			},
@@ -66,9 +318,12 @@ export const rule = createRule({
 		docs: {
 			description: "Avoid using TypeScript's namespaces.",
 		},
+		hasSuggestions: true,
 		messages: {
 			namespace:
 				"This namespace will not be allowed under TypeScript's --erasableSyntaxOnly.",
+			namespaceObjectFix: "Replace the namespace with an object.",
+			namespaceRemoveFix: "Remove the namespace, keeping its contents.",
 		},
 		schema: [],
 		type: "problem",

--- a/src/rules/namespaces.ts
+++ b/src/rules/namespaces.ts
@@ -156,8 +156,6 @@ export const rule = createRule({
 
 						declarators.push({
 							init,
-							// Identifier ranges include any type annotation, which an
-							// object property can't have.
 							nameEnd: id.typeAnnotation?.range[0] ?? id.range[1],
 							nameStart: id.range[0],
 						});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds two suggestions to the `namespaces` rule:

- _Remove the namespace, keeping its contents._: deletes the `namespace Values {` and `}` wrappers, and the members' `export` keywords if the namespace itself wasn't exported
- _Replace the namespace with an object._: turns the namespace into a `const Values = { ... }` object, with exported variables becoming properties and exported functions becoming methods

Both suggestions are only offered for namespaces whose statements are all exported variable declarations (with initializers) and function declarations, since other members (nested namespaces, classes, enums, `declare`d members) don't have a straightforward object equivalent. They're also both skipped for self-referential namespaces, per the issue.

The object suggestion is additionally skipped when a member is referenced by another member, as those references would no longer resolve once the members become object properties:

```ts
namespace Values {
	export const value = "a";
	export function getValue() {
		return value;
	}
}
```

❎