### PR TITLE
feat: add suggestion to parameter-properties rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ These are all set to `"error"` in the recommended config:
 | [enums](docs/rules/enums.md)                               | Avoid using TypeScript's enums.                      | 💡  |
 | [import-aliases](docs/rules/import-aliases.md)             | Avoid using TypeScript's import aliases.             | 💡  |
 | [namespaces](docs/rules/namespaces.md)                     | Avoid using TypeScript's namespaces.                 |     |
-| [parameter-properties](docs/rules/parameter-properties.md) | Avoid using TypeScript's class parameter properties. |     |
+| [parameter-properties](docs/rules/parameter-properties.md) | Avoid using TypeScript's class parameter properties. | 💡  |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/parameter-properties.md
+++ b/docs/rules/parameter-properties.md
@@ -2,12 +2,27 @@
 
 📝 Avoid using TypeScript's class parameter properties.
 
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
 <!-- end auto-generated rule header -->
 
 Enforces that code doesn't use TypeScript's class parameter properties:
 
+## Invalid Code
+
 ```ts
 class Values {
 	constructor(readonly value: number) {}
+}
+```
+
+## Valid Code
+
+```ts
+class Values {
+	readonly value: number;
+	constructor(value: number) {
+		this.value = value;
+	}
 }
 ```

--- a/src/rules/parameter-properties.test.ts
+++ b/src/rules/parameter-properties.test.ts
@@ -18,6 +18,21 @@ ruleTester.run("parameter-properties", rule, {
 					endLine: 4,
 					line: 4,
 					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					private value: number;
+					constructor(
+						value: number,
+					) {
+						this.value = value;
+					}
+				}
+			`,
+						},
+					],
 				},
 			],
 		},
@@ -33,6 +48,205 @@ ruleTester.run("parameter-properties", rule, {
 				{
 					column: 7,
 					endColumn: 29,
+					endLine: 4,
+					line: 4,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					readonly value: number;
+					constructor(
+						value: number,
+					) {
+						this.value = value;
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					constructor(
+						protected readonly value: number = 123,
+					) {
+						console.log(value);
+					}
+				}
+			`,
+			errors: [
+				{
+					column: 7,
+					endColumn: 45,
+					endLine: 4,
+					line: 4,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					protected readonly value: number;
+					constructor(
+						value: number = 123,
+					) {
+						this.value = value;
+						console.log(value);
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					constructor(
+						public first: string,
+						private second?: number,
+					) {}
+				}
+			`,
+			errors: [
+				{
+					column: 7,
+					endColumn: 27,
+					endLine: 4,
+					line: 4,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					public first: string;
+					constructor(
+						first: string,
+						private second?: number,
+					) {
+						this.first = first;
+					}
+				}
+			`,
+						},
+					],
+				},
+				{
+					column: 7,
+					endColumn: 30,
+					endLine: 5,
+					line: 5,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					private second?: number;
+					constructor(
+						public first: string,
+						second?: number,
+					) {
+						this.second = second;
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values extends Base {
+					constructor(
+						private value: number,
+					) {
+						super();
+					}
+				}
+			`,
+			errors: [
+				{
+					column: 7,
+					endColumn: 28,
+					endLine: 4,
+					line: 4,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values extends Base {
+					private value: number;
+					constructor(
+						value: number,
+					) {
+						super();
+						this.value = value;
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					constructor(
+						private value,
+					) {}
+				}
+			`,
+			errors: [
+				{
+					column: 7,
+					endColumn: 20,
+					endLine: 4,
+					line: 4,
+					messageId: "parameterProperty",
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					constructor(
+						@decorator() private value: number,
+					) {}
+				}
+			`,
+			errors: [
+				{
+					column: 7,
+					endColumn: 41,
+					endLine: 4,
+					line: 4,
+					messageId: "parameterProperty",
+				},
+			],
+		},
+		{
+			code: `
+				class Values extends Base {
+					constructor(
+						private value: number,
+					) {}
+				}
+			`,
+			errors: [
+				{
+					column: 7,
+					endColumn: 28,
 					endLine: 4,
 					line: 4,
 					messageId: "parameterProperty",

--- a/src/rules/parameter-properties.test.ts
+++ b/src/rules/parameter-properties.test.ts
@@ -253,6 +253,460 @@ ruleTester.run("parameter-properties", rule, {
 				},
 			],
 		},
+		{
+			code: `
+				class Values extends Base {
+					constructor(override readonly value: number) {
+						super();
+					}
+				}
+			`,
+			errors: [
+				{
+					column: 18,
+					endColumn: 49,
+					endLine: 3,
+					line: 3,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values extends Base {
+					override readonly value: number;
+					constructor(value: number) {
+						super();
+						this.value = value;
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					protected constructor(private value: number) {}
+				}
+			`,
+			errors: [
+				{
+					column: 28,
+					endColumn: 49,
+					endLine: 3,
+					line: 3,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					private value: number;
+					protected constructor(value: number) {
+						this.value = value;
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				const Values = class {
+					constructor(private value: number) {}
+				};
+			`,
+			errors: [
+				{
+					column: 18,
+					endColumn: 39,
+					endLine: 3,
+					line: 3,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				const Values = class {
+					private value: number;
+					constructor(value: number) {
+						this.value = value;
+					}
+				};
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					constructor(value: number);
+					constructor(private value: number) {}
+				}
+			`,
+			errors: [
+				{
+					column: 18,
+					endColumn: 39,
+					endLine: 4,
+					line: 4,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					private value: number;
+					constructor(value: number);
+					constructor(value: number) {
+						this.value = value;
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values extends Base {
+					constructor(private value: number) {
+						const doubled = value * 2;
+						super(doubled);
+					}
+				}
+			`,
+			errors: [
+				{
+					column: 18,
+					endColumn: 39,
+					endLine: 3,
+					line: 3,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values extends Base {
+					private value: number;
+					constructor(value: number) {
+						const doubled = value * 2;
+						super(doubled);
+						this.value = value;
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values extends Base {
+					constructor(private value: number) {
+						if (value) {
+							super(value);
+						} else {
+							super(0);
+						}
+					}
+				}
+			`,
+			errors: [
+				{
+					column: 18,
+					endColumn: 39,
+					endLine: 3,
+					line: 3,
+					messageId: "parameterProperty",
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					other = 1;
+					constructor(private value: number) {}
+					method() {}
+				}
+			`,
+			errors: [
+				{
+					column: 18,
+					endColumn: 39,
+					endLine: 4,
+					line: 4,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					other = 1;
+					private value: number;
+					constructor(value: number) {
+						this.value = value;
+					}
+					method() {}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					constructor(private value: number) {
+						// A comment.
+					}
+				}
+			`,
+			errors: [
+				{
+					column: 18,
+					endColumn: 39,
+					endLine: 3,
+					line: 3,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					private value: number;
+					constructor(value: number) {
+						this.value = value;
+						// A comment.
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					constructor(/* a */ private /* b */ value /* c */: number) {}
+				}
+			`,
+			errors: [
+				{
+					column: 26,
+					endColumn: 63,
+					endLine: 3,
+					line: 3,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					private /* b */ value /* c */: number;
+					constructor(/* a */ value /* c */: number) {
+						this.value = value;
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					constructor(
+						private value: {
+							a: string;
+						},
+					) {}
+				}
+			`,
+			errors: [
+				{
+					column: 7,
+					endColumn: 8,
+					endLine: 6,
+					line: 4,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					private value: {
+							a: string;
+						};
+					constructor(
+						value: {
+							a: string;
+						},
+					) {
+						this.value = value;
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					constructor(private callback: () => void = () => {}) {}
+				}
+			`,
+			errors: [
+				{
+					column: 18,
+					endColumn: 57,
+					endLine: 3,
+					line: 3,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					private callback: () => void;
+					constructor(callback: () => void = () => {}) {
+						this.callback = callback;
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				class Values {
+					constructor(private first: string, private second) {}
+				}
+			`,
+			errors: [
+				{
+					column: 18,
+					endColumn: 39,
+					endLine: 3,
+					line: 3,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				class Values {
+					private first: string;
+					constructor(first: string, private second) {
+						this.first = first;
+					}
+				}
+			`,
+						},
+					],
+				},
+				{
+					column: 41,
+					endColumn: 55,
+					endLine: 3,
+					line: 3,
+					messageId: "parameterProperty",
+				},
+			],
+		},
+		{
+			code: `
+				function make() {
+					class Values {
+						constructor(private value: number) {}
+					}
+				}
+			`,
+			errors: [
+				{
+					column: 19,
+					endColumn: 40,
+					endLine: 4,
+					line: 4,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `
+				function make() {
+					class Values {
+						private value: number;
+						constructor(value: number) {
+							this.value = value;
+						}
+					}
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `class Values { constructor(private value: number) {} }`,
+			errors: [
+				{
+					column: 28,
+					endColumn: 49,
+					endLine: 1,
+					line: 1,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `class Values { private value: number;
+constructor(value: number) {
+	this.value = value;
+} }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `class Values {
+    constructor(private value: number) {}
+}`,
+			errors: [
+				{
+					column: 17,
+					endColumn: 38,
+					endLine: 2,
+					line: 2,
+					messageId: "parameterProperty",
+					suggestions: [
+						{
+							messageId: "parameterPropertyFix",
+							output: `class Values {
+    private value: number;
+    constructor(value: number) {
+        this.value = value;
+    }
+}`,
+						},
+					],
+				},
+			],
+		},
 	],
 	valid: [
 		`

--- a/src/rules/parameter-properties.ts
+++ b/src/rules/parameter-properties.ts
@@ -2,6 +2,16 @@ import { AST_NODE_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
 
 import { createRule } from "../utils.js";
 
+function getFirstConstructor(method: TSESTree.MethodDefinition) {
+	return (
+		method.parent.body.find(
+			(member) =>
+				member.type === AST_NODE_TYPES.MethodDefinition &&
+				member.kind === "constructor",
+		) ?? method
+	);
+}
+
 function getLineIndentation(line: string) {
 	return /^\s*/.exec(line)?.[0] ?? "";
 }
@@ -48,22 +58,26 @@ export const rule = createRule({
 				return undefined;
 			}
 
+			// Overload signatures must stay adjacent to their implementation.
+			const target = getFirstConstructor(method);
 			const modifiers = context.sourceCode
 				.getText()
 				.slice(node.range[0], node.parameter.range[0]);
-			const property = `${modifiers}${context.sourceCode.getText(name)};\n${getIndentation(method)}`;
+			const property = `${modifiers}${context.sourceCode.getText(name)};\n${getIndentation(target)}`;
 			const assignment = `\n${getInnerIndentation(method)}this.${name.name} = ${name.name};`;
+			const isBodyEmpty =
+				!body.body.length && !context.sourceCode.getCommentsInside(body).length;
 
 			return [
 				{
 					fix: (fixer: TSESLint.RuleFixer) => [
-						fixer.insertTextBefore(method, property),
+						fixer.insertTextBefore(target, property),
 						fixer.removeRange([node.range[0], node.parameter.range[0]]),
 						superCall
 							? fixer.insertTextAfter(superCall, assignment)
 							: fixer.insertTextAfterRange(
 									[body.range[0], body.range[0] + 1],
-									`${assignment}${body.body.length ? "" : `\n${getIndentation(method)}`}`,
+									`${assignment}${isBodyEmpty ? `\n${getIndentation(method)}` : ""}`,
 								),
 					],
 					messageId: "parameterPropertyFix" as const,
@@ -71,9 +85,9 @@ export const rule = createRule({
 			];
 		}
 
-		function getIndentation(method: TSESTree.MethodDefinition) {
+		function getIndentation(member: TSESTree.Node) {
 			return getLineIndentation(
-				context.sourceCode.lines[method.loc.start.line - 1],
+				context.sourceCode.lines[member.loc.start.line - 1],
 			);
 		}
 

--- a/src/rules/parameter-properties.ts
+++ b/src/rules/parameter-properties.ts
@@ -1,12 +1,103 @@
+import { AST_NODE_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
+
 import { createRule } from "../utils.js";
+
+function getLineIndentation(line: string) {
+	return /^\s*/.exec(line)?.[0] ?? "";
+}
+
+function getPropertyName(node: TSESTree.TSParameterProperty) {
+	const { parameter } = node;
+	const name =
+		parameter.type === AST_NODE_TYPES.AssignmentPattern
+			? parameter.left
+			: parameter;
+
+	// Class properties need a type annotation: unlike parameters, they can't
+	// infer one from a default value.
+	return name.typeAnnotation ? name : undefined;
+}
+
+function getSuperCall(body: TSESTree.BlockStatement) {
+	return body.body.find(
+		(statement) =>
+			statement.type === AST_NODE_TYPES.ExpressionStatement &&
+			statement.expression.type === AST_NODE_TYPES.CallExpression &&
+			statement.expression.callee.type === AST_NODE_TYPES.Super,
+	);
+}
 
 export const rule = createRule({
 	create(context) {
+		function createSuggestions(node: TSESTree.TSParameterProperty) {
+			const { body } = node.parent;
+			const method = node.parent.parent;
+			const name = getPropertyName(node);
+
+			if (
+				!name ||
+				node.decorators.length ||
+				method.type !== AST_NODE_TYPES.MethodDefinition ||
+				body?.type !== AST_NODE_TYPES.BlockStatement
+			) {
+				return undefined;
+			}
+
+			// Assignments in a derived class' constructor must come after super().
+			const { superClass } = method.parent.parent;
+			const superCall = superClass ? getSuperCall(body) : undefined;
+
+			if (superClass && !superCall) {
+				return undefined;
+			}
+
+			const modifiers = context.sourceCode
+				.getText()
+				.slice(node.range[0], node.parameter.range[0]);
+			const property = `${modifiers}${context.sourceCode.getText(name)};\n${getIndentation(method)}`;
+			const assignment = `\n${getInnerIndentation(method)}this.${name.name} = ${name.name};`;
+
+			return [
+				{
+					fix: (fixer: TSESLint.RuleFixer) => [
+						fixer.insertTextBefore(method, property),
+						fixer.removeRange([node.range[0], node.parameter.range[0]]),
+						superCall
+							? fixer.insertTextAfter(superCall, assignment)
+							: fixer.insertTextAfterRange(
+									[body.range[0], body.range[0] + 1],
+									`${assignment}${body.body.length ? "" : `\n${getIndentation(method)}`}`,
+								),
+					],
+					messageId: "parameterPropertyFix" as const,
+				},
+			];
+		}
+
+		function getIndentation(method: TSESTree.MethodDefinition) {
+			return getLineIndentation(
+				context.sourceCode.lines[method.loc.start.line - 1],
+			);
+		}
+
+		function getInnerIndentation(method: TSESTree.MethodDefinition) {
+			const classIndentation = getLineIndentation(
+				context.sourceCode.lines[method.parent.parent.loc.start.line - 1],
+			);
+			const methodIndentation = getIndentation(method);
+
+			return (
+				methodIndentation +
+				(methodIndentation.slice(classIndentation.length) || "\t")
+			);
+		}
+
 		return {
 			TSParameterProperty(node) {
 				context.report({
 					messageId: "parameterProperty",
 					node,
+					suggest: createSuggestions(node),
 				});
 			},
 		};
@@ -16,9 +107,12 @@ export const rule = createRule({
 		docs: {
 			description: "Avoid using TypeScript's class parameter properties.",
 		},
+		hasSuggestions: true,
 		messages: {
 			parameterProperty:
 				"This parameter property will not be allowed under TypeScript's --erasableSyntaxOnly.",
+			parameterPropertyFix:
+				"Replace the parameter property with a class property.",
 		},
 		schema: [],
 		type: "problem",

--- a/src/rules/parameter-properties.ts
+++ b/src/rules/parameter-properties.ts
@@ -3,17 +3,15 @@ import { AST_NODE_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
 import { createRule } from "../utils.js";
 
 function getFirstConstructor(method: TSESTree.MethodDefinition) {
-	return (
-		method.parent.body.find(
-			(member) =>
-				member.type === AST_NODE_TYPES.MethodDefinition &&
-				member.kind === "constructor",
-		) ?? method
-	);
+	return method.parent.body.find(
+		(member) =>
+			member.type === AST_NODE_TYPES.MethodDefinition &&
+			member.kind === "constructor",
+	) as TSESTree.MethodDefinition;
 }
 
 function getLineIndentation(line: string) {
-	return /^\s*/.exec(line)?.[0] ?? "";
+	return line.slice(0, line.length - line.trimStart().length);
 }
 
 function getPropertyName(node: TSESTree.TSParameterProperty) {

--- a/src/rules/parameter-properties.ts
+++ b/src/rules/parameter-properties.ts
@@ -56,7 +56,6 @@ export const rule = createRule({
 				return undefined;
 			}
 
-			// Overload signatures must stay adjacent to their implementation.
 			const target = getFirstConstructor(method);
 			const modifiers = context.sourceCode
 				.getText()

--- a/src/rules/parameter-properties.ts
+++ b/src/rules/parameter-properties.ts
@@ -13,8 +13,6 @@ function getPropertyName(node: TSESTree.TSParameterProperty) {
 			? parameter.left
 			: parameter;
 
-	// Class properties need a type annotation: unlike parameters, they can't
-	// infer one from a default value.
 	return name.typeAnnotation ? name : undefined;
 }
 
@@ -43,7 +41,6 @@ export const rule = createRule({
 				return undefined;
 			}
 
-			// Assignments in a derived class' constructor must come after super().
 			const { superClass } = method.parent.parent;
 			const superCall = superClass ? getSuperCall(body) : undefined;
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a _Replace the parameter property with a class property._ suggestion to the `parameter-properties` rule. It moves the parameter's modifiers and name onto a class property declared right before the constructor, then assigns the parameter to it inside the constructor:

```ts
class Values {
	readonly value: number;
	constructor(value: number) {
		this.value = value;
	}
}
```

❎