### PR TITLE
feat: add export-aliases rule for CJS-style export= assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These are all set to `"error"` in the recommended config:
 | Name                                                       | Description                                          | 💡  |
 | :--------------------------------------------------------- | :--------------------------------------------------- | :-- |
 | [enums](docs/rules/enums.md)                               | Avoid using TypeScript's enums.                      | 💡  |
+| [export-aliases](docs/rules/export-aliases.md)             | Avoid using TypeScript's export aliases.             | 💡  |
 | [import-aliases](docs/rules/import-aliases.md)             | Avoid using TypeScript's import aliases.             | 💡  |
 | [namespaces](docs/rules/namespaces.md)                     | Avoid using TypeScript's namespaces.                 |     |
 | [parameter-properties](docs/rules/parameter-properties.md) | Avoid using TypeScript's class parameter properties. |     |

--- a/docs/rules/export-aliases.md
+++ b/docs/rules/export-aliases.md
@@ -1,0 +1,21 @@
+# export-aliases
+
+📝 Avoid using TypeScript's export aliases.
+
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
+<!-- end auto-generated rule header -->
+
+Enforces that code doesn't use TypeScript's `export =`s:
+
+## Invalid Code
+
+```ts
+export = values;
+```
+
+## Valid Code
+
+```ts
+export default values;
+```

--- a/src/rules/export-aliases.test.ts
+++ b/src/rules/export-aliases.test.ts
@@ -1,0 +1,52 @@
+import { rule } from "./export-aliases.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("export-aliases", rule, {
+	invalid: [
+		{
+			code: `export = values;`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 17,
+					endLine: 1,
+					line: 1,
+					messageId: "exportAlias",
+					suggestions: [
+						{
+							messageId: "exportAliasDefaultFix",
+							output: `export default values;`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `export = { value: 'a' }`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 24,
+					endLine: 1,
+					line: 1,
+					messageId: "exportAlias",
+					suggestions: [
+						{
+							messageId: "exportAliasDefaultFix",
+							output: `export default { value: 'a' };`,
+						},
+					],
+				},
+			],
+		},
+	],
+	valid: [
+		`export default values;`,
+		`export { values };`,
+		`
+			declare module 'values' {
+				export = values;
+			}
+		`,
+	],
+});

--- a/src/rules/export-aliases.test.ts
+++ b/src/rules/export-aliases.test.ts
@@ -33,7 +33,137 @@ ruleTester.run("export-aliases", rule, {
 					suggestions: [
 						{
 							messageId: "exportAliasDefaultFix",
-							output: `export default { value: 'a' };`,
+							output: `export default { value: 'a' }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `export=values;`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 15,
+					endLine: 1,
+					line: 1,
+					messageId: "exportAlias",
+					suggestions: [
+						{
+							messageId: "exportAliasDefaultFix",
+							output: `export default values;`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `export /* a */ = /* b */ values; // c`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 33,
+					endLine: 1,
+					line: 1,
+					messageId: "exportAlias",
+					suggestions: [
+						{
+							messageId: "exportAliasDefaultFix",
+							output: `export /* a */ default /* b */ values; // c`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `export = values.nested.deeper;`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 31,
+					endLine: 1,
+					line: 1,
+					messageId: "exportAlias",
+					suggestions: [
+						{
+							messageId: "exportAliasDefaultFix",
+							output: `export default values.nested.deeper;`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `export = class Values {};`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 26,
+					endLine: 1,
+					line: 1,
+					messageId: "exportAlias",
+					suggestions: [
+						{
+							messageId: "exportAliasDefaultFix",
+							output: `export default class Values {};`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `export = function values() {};`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 31,
+					endLine: 1,
+					line: 1,
+					messageId: "exportAlias",
+					suggestions: [
+						{
+							messageId: "exportAliasDefaultFix",
+							output: `export default function values() {};`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `export = () => 'a';`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 20,
+					endLine: 1,
+					line: 1,
+					messageId: "exportAlias",
+					suggestions: [
+						{
+							messageId: "exportAliasDefaultFix",
+							output: `export default () => 'a';`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `export = {
+	value: 'a',
+};`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 3,
+					endLine: 3,
+					line: 1,
+					messageId: "exportAlias",
+					suggestions: [
+						{
+							messageId: "exportAliasDefaultFix",
+							output: `export default {
+	value: 'a',
+};`,
 						},
 					],
 				},
@@ -43,8 +173,15 @@ ruleTester.run("export-aliases", rule, {
 	valid: [
 		`export default values;`,
 		`export { values };`,
+		`export as namespace Values;`,
+		`import values = require('values');`,
 		`
 			declare module 'values' {
+				export = values;
+			}
+		`,
+		`
+			declare global {
 				export = values;
 			}
 		`,

--- a/src/rules/export-aliases.ts
+++ b/src/rules/export-aliases.ts
@@ -10,15 +10,26 @@ export const rule = createRule({
 					return;
 				}
 
+				const equals = context.sourceCode.getTokenBefore(
+					node.expression,
+					(token) => token.value === "=",
+				);
+
 				context.report({
 					messageId: "exportAlias",
 					node,
-					suggest: [
+					suggest: equals && [
 						{
 							fix(fixer) {
+								const text = context.sourceCode.getText();
+
 								return fixer.replaceText(
-									node,
-									`export default ${context.sourceCode.getText(node.expression)};`,
+									equals,
+									[
+										/\s/.test(text[equals.range[0] - 1]) ? "" : " ",
+										"default",
+										/\s/.test(text[equals.range[1]]) ? "" : " ",
+									].join(""),
 								);
 							},
 							messageId: "exportAliasDefaultFix",

--- a/src/rules/export-aliases.ts
+++ b/src/rules/export-aliases.ts
@@ -6,8 +6,6 @@ export const rule = createRule({
 	create(context) {
 		return {
 			TSExportAssignment(node) {
-				// `export =`s are still allowed in ambient contexts such as
-				// `declare module`s, which don't emit any JavaScript.
 				if (node.parent.type !== AST_NODE_TYPES.Program) {
 					return;
 				}

--- a/src/rules/export-aliases.ts
+++ b/src/rules/export-aliases.ts
@@ -1,0 +1,48 @@
+import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+
+import { createRule } from "../utils.js";
+
+export const rule = createRule({
+	create(context) {
+		return {
+			TSExportAssignment(node) {
+				// `export =`s are still allowed in ambient contexts such as
+				// `declare module`s, which don't emit any JavaScript.
+				if (node.parent.type !== AST_NODE_TYPES.Program) {
+					return;
+				}
+
+				context.report({
+					messageId: "exportAlias",
+					node,
+					suggest: [
+						{
+							fix(fixer) {
+								return fixer.replaceText(
+									node,
+									`export default ${context.sourceCode.getText(node.expression)};`,
+								);
+							},
+							messageId: "exportAliasDefaultFix",
+						},
+					],
+				});
+			},
+		};
+	},
+	defaultOptions: [],
+	meta: {
+		docs: {
+			description: "Avoid using TypeScript's export aliases.",
+		},
+		hasSuggestions: true,
+		messages: {
+			exportAlias:
+				"This export alias will not be allowed under TypeScript's --erasableSyntaxOnly.",
+			exportAliasDefaultFix: "Switch to default export.",
+		},
+		schema: [],
+		type: "problem",
+	},
+	name: "export-aliases",
+});

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,10 +1,12 @@
 import { rule as enums } from "./enums.js";
+import { rule as exportAliases } from "./export-aliases.js";
 import { rule as importAliases } from "./import-aliases.js";
 import { rule as namespaces } from "./namespaces.js";
 import { rule as parameterProperties } from "./parameter-properties.js";
 
 export const rules = {
 	enums,
+	"export-aliases": exportAliases,
 	"import-aliases": importAliases,
 	namespaces,
 	"parameter-properties": parameterProperties,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #24
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds an `erasable-syntax-only/export-aliases` rule reporting on `export =` assignments, which [microsoft/TypeScript#61175](https://github.com/microsoft/TypeScript/pull/61175) added to `erasableSyntaxOnly`. It comes with a _Switch to default export._ suggestion:

```ts
export = values;
// 💡 export default values;
```

`export =`s inside `declare module`s aren't reported, as TypeScript still allows them there under `erasableSyntaxOnly`:

```ts
declare module "values" {
	export = values;
}
```

Note that top-level `export =`s in `.d.ts` files are reported, the same way the other rules in this plugin report on syntax in declaration files. Happy to add file-level filtering here or in a followup if you'd like.

❎