### PR TITLE
fix: correct enums suggestion for const and declared enums

### DIFF
--- a/src/rules/enums.test.ts
+++ b/src/rules/enums.test.ts
@@ -135,6 +135,122 @@ export type Values = typeof Values[keyof typeof Values]`,
 				},
 			],
 		},
+		{
+			code: `const enum Values {
+  A
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `const Values = {
+  A: 0
+} as const
+
+type Values = typeof Values[keyof typeof Values]`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `export const enum Mode {
+  build = 'build',
+  debug = 'debug'
+}`,
+			errors: [
+				{
+					column: 8,
+					endColumn: 2,
+					endLine: 4,
+					line: 1,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `export const Mode = {
+  build: 'build',
+  debug: 'debug'
+} as const
+
+export type Mode = typeof Mode[keyof typeof Mode]`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `/* a */ export /* b */ const /* c */ enum /* d */ Values {
+  A
+}`,
+			errors: [
+				{
+					column: 24,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `/* a */ export /* b */ const /* d */ Values = {
+  A: 0
+} as const
+
+export type Values = typeof Values[keyof typeof Values]`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `declare enum Values {
+  A
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+				},
+			],
+		},
+		{
+			code: `declare const enum Values {
+  A
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+				},
+			],
+		},
+		{
+			code: `export declare const enum Values {
+  A
+}`,
+			errors: [
+				{
+					column: 8,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+				},
+			],
+		},
 	],
 	valid: [`const Values = {};`, `const Values = {} as const;`],
 });

--- a/src/rules/enums.ts
+++ b/src/rules/enums.ts
@@ -1,12 +1,39 @@
-import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 
 import { createRule } from "../utils.js";
 
 export const rule = createRule({
 	create(context) {
+		function getConstReplacementRange(
+			node: TSESTree.TSEnumDeclaration,
+		): TSESTree.Range | undefined {
+			const enumToken = context.sourceCode.getFirstToken(
+				node,
+				(token) => token.value === "enum",
+			);
+
+			// Ambient enums can't be given an initializer, so they can't be
+			// switched to an object literal.
+			if (node.declare || !enumToken) {
+				return undefined;
+			}
+
+			if (!node.const) {
+				return enumToken.range;
+			}
+
+			const constToken = context.sourceCode.getFirstToken(
+				node,
+				(token) => token.value === "const",
+			);
+
+			return constToken ? [constToken.range[0], enumToken.range[1]] : undefined;
+		}
+
 		return {
 			TSEnumDeclaration(node) {
 				const name = node.id.name;
+				const constReplacementRange = getConstReplacementRange(node);
 				const isExported =
 					node.parent.type === AST_NODE_TYPES.ExportNamedDeclaration;
 				let canSuggestion = true;
@@ -50,30 +77,28 @@ export const rule = createRule({
 				context.report({
 					messageId: "enum",
 					node,
-					suggest: canSuggestion
-						? [
-								{
-									fix(fixer) {
-										return [
-											fixer.replaceTextRange(
-												[node.range[0], node.range[0] + 4],
-												"const",
-											),
-											fixer.insertTextBefore(node.body, "= "),
-											...body.map(({ content, range }) =>
-												fixer.replaceTextRange(range, content),
-											),
-											fixer.insertTextAfter(node.body, " as const"),
-											fixer.insertTextAfter(
-												node.parent.parent ?? node.parent,
-												`\n\n${isExported ? "export " : ""}type ${name} = typeof ${name}[keyof typeof ${name}]`,
-											),
-										];
+					suggest:
+						canSuggestion && constReplacementRange
+							? [
+									{
+										fix(fixer) {
+											return [
+												fixer.replaceTextRange(constReplacementRange, "const"),
+												fixer.insertTextBefore(node.body, "= "),
+												...body.map(({ content, range }) =>
+													fixer.replaceTextRange(range, content),
+												),
+												fixer.insertTextAfter(node.body, " as const"),
+												fixer.insertTextAfter(
+													node.parent.parent ?? node.parent,
+													`\n\n${isExported ? "export " : ""}type ${name} = typeof ${name}[keyof typeof ${name}]`,
+												),
+											];
+										},
+										messageId: "enumFix",
 									},
-									messageId: "enumFix",
-								},
-							]
-						: null,
+								]
+							: null,
 				});
 			},
 		};

--- a/src/rules/enums.ts
+++ b/src/rules/enums.ts
@@ -12,8 +12,6 @@ export const rule = createRule({
 				(token) => token.value === "enum",
 			);
 
-			// Ambient enums can't be given an initializer, so they can't be
-			// switched to an object literal.
 			if (node.declare || !enumToken) {
 				return undefined;
 			}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #281
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The `enums` suggestion used to naively replace the declaration's first four characters with `const`, which assumed the declaration started with `enum`. `export const enum Mode {` therefore became `export constt enum Mode = {`.

The suggestion now finds the `enum` keyword token and replaces it, along with a preceding `const` keyword when there is one:

```ts
export const enum Mode {
	build = "build",
	debug = "debug",
}
// 💡
export const Mode = {
	build: 'build',
	debug: 'debug'
} as const

export type Mode = typeof Mode[keyof typeof Mode]
```

`declare enum`s hit the same bug (`declare enum A {}` became `constare enum A = {}`). They're now reported without a suggestion, since ambient declarations can't be given an initializer - there's no valid object literal to suggest. Let me know if you'd rather have that part split out into its own PR.

❎