### PR TITLE
fix(enums): correct suggestion values, scope, and quoted member names

### DIFF
--- a/src/rules/enums.test.ts
+++ b/src/rules/enums.test.ts
@@ -97,9 +97,9 @@ type Values = typeof Values[keyof typeof Values]`,
 							messageId: "enumFix",
 							output: `/* a */ /* b */ export /* c */ /* d */ const /* e */ /* f */ Values /* g */ /* h */ = { /* i */ /* j */
   /* k */ /* l */ A: 0 /* m */ /* n */
-/* o */ /* p */ } as const /* q */ /* r */
+/* o */ /* p */ } as const
 
-export type Values = typeof Values[keyof typeof Values]`,
+export type Values = typeof Values[keyof typeof Values] /* q */ /* r */`,
 						},
 					],
 				},
@@ -248,6 +248,326 @@ export type Values = typeof Values[keyof typeof Values]`,
 					endLine: 3,
 					line: 1,
 					messageId: "enum",
+				},
+			],
+		},
+		{
+			code: `namespace Values {
+  export enum Inner {
+    A
+  }
+}`,
+			errors: [
+				{
+					column: 10,
+					endColumn: 4,
+					endLine: 4,
+					line: 2,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `namespace Values {
+  export const Inner = {
+    A: 0
+  } as const
+
+  export type Inner = typeof Inner[keyof typeof Inner]
+}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `namespace Values {
+  enum Inner {
+    A
+  }
+}`,
+			errors: [
+				{
+					column: 3,
+					endColumn: 4,
+					endLine: 4,
+					line: 2,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `namespace Values {
+  const Inner = {
+    A: 0
+  } as const
+
+  type Inner = typeof Inner[keyof typeof Inner]
+}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `function make() {
+  enum Values {
+    A
+  }
+}`,
+			errors: [
+				{
+					column: 3,
+					endColumn: 4,
+					endLine: 4,
+					line: 2,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `function make() {
+  const Values = {
+    A: 0
+  } as const
+
+  type Values = typeof Values[keyof typeof Values]
+}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `enum Values {
+  A
+}
+
+console.log(Values.A);`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `const Values = {
+  A: 0
+} as const
+
+type Values = typeof Values[keyof typeof Values]
+
+console.log(Values.A);`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `declare module 'values' {
+  export enum Values {
+    A
+  }
+}`,
+			errors: [
+				{
+					column: 10,
+					endColumn: 4,
+					endLine: 4,
+					line: 2,
+					messageId: "enum",
+				},
+			],
+		},
+		{
+			code: `declare namespace Values {
+  export enum Inner {
+    A
+  }
+}`,
+			errors: [
+				{
+					column: 10,
+					endColumn: 4,
+					endLine: 4,
+					line: 2,
+					messageId: "enum",
+				},
+			],
+		},
+		{
+			code: `enum Values {
+  Shifted = 1 << 2
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `const Values = {
+  Shifted: 1 << 2
+} as const
+
+type Values = typeof Values[keyof typeof Values]`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `enum Values {
+  Concatenated = 'a' + 'b'
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `const Values = {
+  Concatenated: 'a' + 'b'
+} as const
+
+type Values = typeof Values[keyof typeof Values]`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `enum Values {
+  Negative = -1
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `const Values = {
+  Negative: -1
+} as const
+
+type Values = typeof Values[keyof typeof Values]`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `enum Values {
+  Templated = \`a\`
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `const Values = {
+  Templated: \`a\`
+} as const
+
+type Values = typeof Values[keyof typeof Values]`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `enum Values {
+  A = 1,
+  B = A << 1
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 4,
+					line: 1,
+					messageId: "enum",
+				},
+			],
+		},
+		{
+			code: `enum Values {
+  Shifted = 1 << 2,
+  Next
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 4,
+					line: 1,
+					messageId: "enum",
+				},
+			],
+		},
+		{
+			code: `enum Values {
+  'a-b' = 1
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 3,
+					line: 1,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `const Values = {
+  'a-b': 1
+} as const
+
+type Values = typeof Values[keyof typeof Values]`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `const OUTSIDE = 3;
+enum Values {
+  A = OUTSIDE
+}`,
+			errors: [
+				{
+					column: 1,
+					endColumn: 2,
+					endLine: 4,
+					line: 2,
+					messageId: "enum",
+					suggestions: [
+						{
+							messageId: "enumFix",
+							output: `const OUTSIDE = 3;
+const Values = {
+  A: OUTSIDE
+} as const
+
+type Values = typeof Values[keyof typeof Values]`,
+						},
+					],
 				},
 			],
 		},

--- a/src/rules/enums.ts
+++ b/src/rules/enums.ts
@@ -1,6 +1,36 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import {
+	AST_NODE_TYPES,
+	AST_TOKEN_TYPES,
+	TSESTree,
+} from "@typescript-eslint/utils";
 
 import { createRule } from "../utils.js";
+
+interface EnumMemberContent {
+	content: string;
+	range: TSESTree.Range;
+}
+
+function isAmbient(node: TSESTree.TSEnumDeclaration) {
+	if (node.declare) {
+		return true;
+	}
+
+	for (
+		let ancestor: TSESTree.Node | undefined = node.parent;
+		ancestor;
+		ancestor = ancestor.parent
+	) {
+		if (
+			ancestor.type === AST_NODE_TYPES.TSModuleDeclaration &&
+			ancestor.declare
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
 
 export const rule = createRule({
 	create(context) {
@@ -12,7 +42,7 @@ export const rule = createRule({
 				(token) => token.value === "enum",
 			);
 
-			if (node.declare || !enumToken) {
+			if (!enumToken) {
 				return undefined;
 			}
 
@@ -28,68 +58,103 @@ export const rule = createRule({
 			return constToken ? [constToken.range[0], enumToken.range[1]] : undefined;
 		}
 
+		function getMemberContents(
+			node: TSESTree.TSEnumDeclaration,
+		): EnumMemberContent[] | undefined {
+			const memberNames = new Set(
+				node.body.members.map((member) =>
+					member.id.type === AST_NODE_TYPES.Identifier
+						? member.id.name
+						: undefined,
+				),
+			);
+			const contents: EnumMemberContent[] = [];
+			let nextAutoValue: number | undefined = 0;
+
+			for (const member of node.body.members) {
+				const name = context.sourceCode.getText(member.id);
+
+				if (!member.initializer) {
+					if (nextAutoValue === undefined) {
+						return undefined;
+					}
+
+					contents.push({
+						content: `${name}: ${nextAutoValue.toString()}`,
+						range: member.range,
+					});
+					nextAutoValue += 1;
+					continue;
+				}
+
+				if (referencesMember(member.initializer, memberNames)) {
+					return undefined;
+				}
+
+				contents.push({
+					content: `${name}: ${context.sourceCode.getText(member.initializer)}`,
+					range: member.range,
+				});
+
+				// Members after a computed value can't be given an auto-incremented one.
+				nextAutoValue =
+					member.initializer.type === AST_NODE_TYPES.Literal &&
+					typeof member.initializer.value === "number"
+						? member.initializer.value + 1
+						: undefined;
+			}
+
+			return contents;
+		}
+
+		function getIndentation(node: TSESTree.Node) {
+			return /^\s*/.exec(
+				context.sourceCode.lines[node.loc.start.line - 1],
+			)?.[0];
+		}
+
+		function referencesMember(
+			initializer: TSESTree.Expression,
+			memberNames: Set<string | undefined>,
+		) {
+			return context.sourceCode
+				.getTokens(initializer)
+				.some(
+					(token) =>
+						token.type === AST_TOKEN_TYPES.Identifier &&
+						memberNames.has(token.value),
+				);
+		}
+
 		return {
 			TSEnumDeclaration(node) {
 				const name = node.id.name;
+				const target =
+					node.parent.type === AST_NODE_TYPES.ExportNamedDeclaration
+						? node.parent
+						: node;
 				const constReplacementRange = getConstReplacementRange(node);
-				const isExported =
-					node.parent.type === AST_NODE_TYPES.ExportNamedDeclaration;
-				let canSuggestion = true;
-				const body: { content: string; range: [number, number] }[] = [];
-
-				let previousMemberNumericValue = -1;
-				for (const enumMember of node.body.members) {
-					if (
-						enumMember.id.type !== AST_NODE_TYPES.Identifier &&
-						// TODO: Investigate this, can we remove it?
-						// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-						(enumMember.id.type !== AST_NODE_TYPES.Literal ||
-							typeof enumMember.id.value !== "string")
-					) {
-						canSuggestion = false;
-						break;
-					}
-					const propertyName =
-						enumMember.id.type === AST_NODE_TYPES.Identifier
-							? enumMember.id.name
-							: enumMember.id.value;
-					const value =
-						enumMember.initializer?.type === AST_NODE_TYPES.Literal
-							? enumMember.initializer.value
-							: previousMemberNumericValue + 1;
-
-					if (value === null) {
-						canSuggestion = false;
-						break;
-					}
-
-					body.push({
-						content: `${propertyName}: ${typeof value === "string" ? `'${value}'` : value.toString()}`,
-						range: enumMember.range,
-					});
-					if (typeof value === "number") {
-						previousMemberNumericValue = value;
-					}
-				}
+				const contents = isAmbient(node) ? undefined : getMemberContents(node);
+				const indentation = getIndentation(target);
 
 				context.report({
 					messageId: "enum",
 					node,
 					suggest:
-						canSuggestion && constReplacementRange
+						constReplacementRange && contents && indentation !== undefined
 							? [
 									{
 										fix(fixer) {
 											return [
 												fixer.replaceTextRange(constReplacementRange, "const"),
 												fixer.insertTextBefore(node.body, "= "),
-												...body.map(({ content, range }) =>
+												...contents.map(({ content, range }) =>
 													fixer.replaceTextRange(range, content),
 												),
 												fixer.insertTextAfter(node.body, " as const"),
 												fixer.insertTextAfter(
-													node.parent.parent ?? node.parent,
-													`\n\n${isExported ? "export " : ""}type ${name} = typeof ${name}[keyof typeof ${name}]`,
+													target,
+													`\n\n${indentation}${target === node ? "" : "export "}type ${name} = typeof ${name}[keyof typeof ${name}]`,
 												),
 											];
 										},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #281
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Follow-up to #442. Going back over the `enums` suggestion for edge cases turned up three more ways it produced wrong code:

**Non-literal member values were silently replaced with wrong numbers.** Only `Literal` initializers were read; anything else fell through to the auto-increment counter:

```ts
enum Values {
	Shifted = 1 << 2, // 💥 became Shifted: 0, not 4
	Concatenated = 'a' + 'b', // 💥 became Concatenated: 0, not 'ab'
	Negative = -1, // 💥 became Negative: 0
}
```

Initializers are now copied verbatim, so the values stay correct. Two cases can't be converted safely and now get no suggestion: a member whose initializer references a sibling member (`B = A << 1`, which wouldn't resolve as an object property), and a member auto-incrementing off a computed value (`Shifted = 1 << 2, Next`, whose value isn't knowable without evaluating).

**The companion `type` alias was emitted outside the enum's scope.** It was inserted after `node.parent.parent`, which is the enclosing block for a nested enum, so it landed at the end of the file:

```ts
namespace Values {
	export const Inner = { A: 0 } as const
}

export type Inner = typeof Inner[keyof typeof Inner] // 💥 Inner isn't in scope
```

It now goes directly after the enum (or its `export`), indented to match. Enums in an ambient context (`declare module`, `declare namespace`) get no suggestion at all, since ambient declarations can't have initializers.

**String-literal member names produced invalid object keys**: `'a-b' = 1` became `a-b: 1`. Quoted names are now kept quoted.

❎