### PR TITLE
fix(namespaces): only suggest removing unreferenced, non-colliding namespaces

### DIFF
--- a/src/rules/namespaces.test.ts
+++ b/src/rules/namespaces.test.ts
@@ -475,6 +475,390 @@ ruleTester.run("namespaces", rule, {
 				},
 			],
 		},
+		{
+			code: `
+				namespace Values {
+					export const value = 'a';
+				}
+				
+				console.log(Values.value);
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const Values = {
+					value: 'a',
+				};
+				
+				console.log(Values.value);
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				export namespace Values {
+					export const value = 'a';
+				}
+				
+				console.log(Values.value);
+			`,
+			errors: [
+				{
+					column: 12,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				export const Values = {
+					value: 'a',
+				};
+				
+				console.log(Values.value);
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				const value = 'outer';
+				namespace Values {
+					export const value = 'inner';
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 5,
+					line: 3,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const value = 'outer';
+				const Values = {
+					value: 'inner',
+				};
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					export let value = 'a';
+				}
+				
+				Values.value = 'b';
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const Values = {
+					value: 'a',
+				};
+				
+				Values.value = 'b';
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					export const a = 'a'
+					export const b = 'b'
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 5,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				
+					const a = 'a'
+					const b = 'b'
+				
+			`,
+						},
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const Values = {
+					a: 'a',
+					b: 'b',
+				};
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					// Leading.
+					export const a = 'a'; // Trailing.
+					/* Block. */
+					export const b = 'b';
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 7,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				
+					// Leading.
+					const a = 'a'; // Trailing.
+					/* Block. */
+					const b = 'b';
+				
+			`,
+						},
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const Values = {
+					// Leading.
+					a: 'a', // Trailing.
+					/* Block. */
+					b: 'b',
+				};
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				function make() {
+					namespace Values {
+						export const value = 'a';
+					}
+				}
+			`,
+			errors: [
+				{
+					column: 6,
+					endColumn: 7,
+					endLine: 5,
+					line: 3,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				function make() {
+					
+						const value = 'a';
+					
+				}
+			`,
+						},
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				function make() {
+					const Values = {
+						value: 'a',
+					};
+				}
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					export const value: readonly string[] = [];
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				
+					const value: readonly string[] = [];
+				
+			`,
+						},
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const Values = {
+					value: [],
+				};
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					export const run = async () => {};
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+					suggestions: [
+						{
+							messageId: "namespaceRemoveFix",
+							output: `
+				
+					const run = async () => {};
+				
+			`,
+						},
+						{
+							messageId: "namespaceObjectFix",
+							output: `
+				const Values = {
+					run: async () => {},
+				};
+			`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					export const a = 'a';
+				}
+				namespace Values {
+					export const b = 'b';
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 7,
+					line: 5,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				function Values() {}
+				namespace Values {
+					export const value = 'a';
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 5,
+					line: 3,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				interface Values {
+					a: string;
+				}
+				namespace Values {
+					export const value = 'a';
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 7,
+					line: 5,
+					messageId: "namespace",
+				},
+			],
+		},
+		{
+			code: `
+				namespace Values {
+					export const { value } = source;
+				}
+			`,
+			errors: [
+				{
+					column: 5,
+					endColumn: 6,
+					endLine: 4,
+					line: 2,
+					messageId: "namespace",
+				},
+			],
+		},
 	],
 	valid: [
 		`const Values = {};`,

--- a/src/rules/namespaces.ts
+++ b/src/rules/namespaces.ts
@@ -26,6 +26,7 @@ interface ConvertibleStatementBase {
 	declarationRange: TSESTree.Range;
 	isReferenced: boolean;
 	lastToken: TSESTree.Token;
+	names: string[];
 	statement: TSESTree.ExportNamedDeclaration;
 }
 
@@ -124,11 +125,11 @@ export const rule = createRule({
 				return undefined;
 			}
 
-			const isReferenced = context.sourceCode
-				.getDeclaredVariables(declaration)
-				.some((variable) =>
-					variable.references.some((reference) => !reference.init),
-				);
+			const variables = context.sourceCode.getDeclaredVariables(declaration);
+			const isReferenced = variables.some((variable) =>
+				variable.references.some((reference) => !reference.init),
+			);
+			const names = variables.map((variable) => variable.name);
 
 			switch (declaration.type) {
 				case AST_NODE_TYPES.FunctionDeclaration: {
@@ -140,6 +141,7 @@ export const rule = createRule({
 								functionRange,
 								isReferenced,
 								lastToken,
+								names,
 								statement,
 								type: "function",
 							}
@@ -166,6 +168,7 @@ export const rule = createRule({
 						declarators,
 						isReferenced,
 						lastToken,
+						names,
 						statement,
 						type: "variable",
 					};
@@ -208,6 +211,21 @@ export const rule = createRule({
 				);
 		}
 
+		function canRemove(
+			node: TSESTree.TSModuleDeclaration,
+			statements: ConvertibleStatement[],
+		) {
+			const variable = context.sourceCode.getDeclaredVariables(node).at(0);
+
+			return (
+				!!variable &&
+				!variable.references.length &&
+				!statements.some((statement) =>
+					statement.names.some((name) => variable.scope.set.has(name)),
+				)
+			);
+		}
+
 		function createSuggestions(
 			node: TSESTree.TSModuleDeclaration,
 		): TSESLint.SuggestionReportDescriptor<MessageId>[] | undefined {
@@ -219,8 +237,10 @@ export const rule = createRule({
 
 			const { body, id, statements } = convertible;
 
-			const suggestions: TSESLint.SuggestionReportDescriptor<MessageId>[] = [
-				{
+			const suggestions: TSESLint.SuggestionReportDescriptor<MessageId>[] = [];
+
+			if (canRemove(node, statements)) {
+				suggestions.push({
 					*fix(fixer) {
 						const target = skipExportParent(node);
 
@@ -237,8 +257,8 @@ export const rule = createRule({
 						}
 					},
 					messageId: "namespaceRemoveFix",
-				},
-			];
+				});
+			}
 
 			// Members referenced by other members would no longer be in scope as
 			// properties of an object, so only namespaces without them can convert.
@@ -263,7 +283,7 @@ export const rule = createRule({
 				});
 			}
 
-			return suggestions;
+			return suggestions.length ? suggestions : undefined;
 		}
 
 		function* createPropertyFixes(


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Follow-up to #439. The _Remove the namespace, keeping its contents._ suggestion was offered in two situations where it produces code that doesn't compile.

**The namespace's name is still used.** Removing the namespace deletes the binding those usages resolve to:

```ts
namespace Values {
	export const value = "a";
}

console.log(Values.value); // 💥 Values is gone after the suggestion
```

**A hoisted member collides with an existing declaration** in the scope it's hoisted into:

```ts
const value = "outer";
namespace Values {
	export const value = "inner"; // 💥 two `const value` in one scope
}
```

The removal suggestion is now offered only when the namespace has no references and none of its members would collide. Both cases still get the object suggestion, which keeps the `Values.value` call sites working and introduces no new name:

```ts
const Values = {
	value: "a",
};
```

Also adds tests for cases that were already handled correctly but untested: namespaces merged with another namespace, a function, or an interface; destructured members; members without semicolons; interleaved comments; a namespace nested in a function; and type-annotated, `let`, and `async` arrow members.

❎